### PR TITLE
feat(modals): added modal to confirm clear all

### DIFF
--- a/src/components/builder/inputs/Erase.vue
+++ b/src/components/builder/inputs/Erase.vue
@@ -20,8 +20,9 @@ export default defineComponent({
     methods: {
         async openModalToConfirmClear(): Promise<void> {
             const userConfirmed = await pushModal(ConfirmClearAll, { asModal: true });
-            if (userConfirmed) await this.$store.dispatch("builderData/clear");;
+            if (userConfirmed)
+                await this.$store.dispatch('builderData/clear');
         },
-    }
+    },
 })
 </script>

--- a/src/components/builder/inputs/Erase.vue
+++ b/src/components/builder/inputs/Erase.vue
@@ -1,19 +1,27 @@
 <template>
-    <div class="w-full">
-        <Btn class="w-full" @click="clear">Clear All</Btn>
+    <div v-if="getUsedBriqsNb" class="w-full">
+        <Btn class="w-full" @click="openModalToConfirmClear">Clear All</Btn>
     </div>
 </template>
 
 <script lang="ts">
+import ConfirmClearAll from '../modals/ConfirmClearAll.vue';
+import { pushModal } from '../../Modals.vue';
 import { defineComponent } from 'vue';
 export default defineComponent({
-    data() {
-        return {};
-    },
-    methods: {
-        async clear() {
-            await this.$store.dispatch('builderData/clear');
+    computed: {
+        getUsedBriqsNb(): number {
+            let used = 0;
+            for (let mat in this.$store.state.builderData.currentSet.usedByMaterial)
+                used += this.$store.state.builderData.currentSet.usedByMaterial[mat];
+            return used;
         },
     },
-});
+    methods: {
+        async openModalToConfirmClear(): Promise<void> {
+            const userConfirmed = await pushModal(ConfirmClearAll, { asModal: true });
+            if (userConfirmed) await this.$store.dispatch("builderData/clear");;
+        },
+    }
+})
 </script>

--- a/src/components/builder/modals/ConfirmClearAll.vue
+++ b/src/components/builder/modals/ConfirmClearAll.vue
@@ -1,7 +1,7 @@
 <template>
     <Window size="w-max">
         <template #big-title>Clear all</template>
-         <div class="my-4">
+        <div class="my-4">
             <p>All work will be cleared.</p>
         </div>
         <div class="flex justify-between gap-4">

--- a/src/components/builder/modals/ConfirmClearAll.vue
+++ b/src/components/builder/modals/ConfirmClearAll.vue
@@ -1,0 +1,12 @@
+<template>
+    <Window size="w-max">
+        <template #big-title>Clear all</template>
+         <div class="my-4">
+            <p>All work will be cleared.</p>
+        </div>
+        <div class="flex justify-between gap-4">
+            <Btn @click="$emit('close', false)">Cancel</Btn>
+            <Btn @click="$emit('close', true)">Confirm Clear</Btn>
+        </div>
+    </Window>
+</template>


### PR DESCRIPTION
Hi!

Context: https://discord.com/channels/906209682396413972/918903331232043079/967546514681524294

I was enjoying the edit of a set and miscliked on the **_Clear All_.** button.
![image](https://user-images.githubusercontent.com/31159436/164996606-f1fa09bc-308f-42cf-8192-f8555d73268a.png)

Unfortunately I could not manage to undo that misclick.
=> So I thought a [confirmation modal](https://github.com/briqNFT/briq-builder/pull/21/files) would be useful.

![image](https://user-images.githubusercontent.com/31159436/164996475-3bb970fc-a7d2-483e-93b1-2689a4f73dc7.png)

🧱 🧱 🧱 🧱 